### PR TITLE
Remind to run "yarn install" if deps out of date

### DIFF
--- a/bin/pre-start
+++ b/bin/pre-start
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const shell = require("shelljs");
+
+shell.config.silent = true;
+shell.exec("yarn check --integrity");
+if (shell.error()) {
+  console.log(`
+  ERROR: Dependencies are not met. Please run \`yarn install\`.
+`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prestart": "node bin/pre-start",
     "start": "nodemon --watch . --watch .env.development --watch .env.development.local app/server.js",
     "lint": "eslint 'app/**/*.js'",
     "server": "node app/server.js",
@@ -38,6 +39,7 @@
     "lint-staged": "^7.2.0",
     "nodemon": "^1.18.3",
     "prettier": "^1.13.7",
+    "shelljs": "^0.8.2",
     "supertest": "^3.1.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,6 +1705,17 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob@^7.0.0:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -2020,6 +2031,10 @@ inquirer@^5.2.0:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -3879,6 +3894,12 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 referrer-policy@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.1.0.tgz#35774eb735bf50fb6c078e83334b472350207d79"
@@ -4016,6 +4037,12 @@ resolve-url@^0.2.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.6:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -4190,6 +4217,14 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shelljs@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
When developing a project, it is easy to forget to run `yarn install` upon switching branches. If the branch has a different set of dependencies in its package.json or yarn.lock file, the app may still boot up, but you will likely run into errors at some point.

This commit adds a `yarn check --integrity` step, which is an extremely fast check (~ 0.1s) to see if the current lock file and package.json have been `yarn install`'ed. If there is a mismatch, the prestart script will print a reminder and abort starting the app.

This is a cherry-pick from https://github.com/carbonfive/spraygun-react/pull/7