### PR TITLE
Add basic auth support

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,3 +4,8 @@
 
 JWT_SECRET=af759d2677dcd70719a3075afc2e30328738807dafe94566fbcccd7be2cc57f879d411b3a49418646c4dc317fa3d10c9fb5b670ca68d9ba96e77b8d7d0e8465e
 DISABLE_SECURE_COOKIES=1
+
+# 
+# Uncomment and set these to enable basic auth for your app
+#BASIC_AUTH_USER=basic-auth-user
+#BASIC_AUTH_PASSWORD=basic-auth-password

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Verify it is working by making an HTTP request:
 
 <http://localhost:5000/api/hello>
 
+### Basic Auth
+
+Setting both BASIC_AUTH_USER and BASIC_AUTH_PASSWORD in your environment will enable
+basic auth for your app.
+
+
 ## Task reference
 
 - **`yarn start`** starts the Express server listing on port 5000. The server is automatically restarted whenever you make changes.

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -28,3 +28,8 @@ exports.jwt = {
   duration: "1 hour",
   secret: mandatory("JWT_SECRET")
 };
+
+exports.basicAuth = {
+  user: process.env.BASIC_AUTH_USER,
+  password: process.env.BASIC_AUTH_PASSWORD
+};

--- a/app/index.js
+++ b/app/index.js
@@ -1,25 +1,13 @@
 const express = require("express");
 const handleAsync = require("@app/middleware/handle-async");
-const basicAuth = require("express-basic-auth");
 const session = require("@app/middleware/jwt-session");
 const auth = session.authenticate;
-const basicAuthCfg = require("@app/config").basicAuth;
 
 const app = express();
 
 app.use(require("helmet")());
 app.use(require("@app/middleware/logging"));
-
-if (basicAuthCfg.user && basicAuthCfg.password) {
-  app.use(
-    basicAuth({
-      users: {
-        [basicAuthCfg.user]: basicAuthCfg.password
-      },
-      challenge: true
-    })
-  );
-}
+app.use(require("@app/middleware/basic-auth"));
 
 app.use("/api/", require("cookie-parser")());
 app.use("/api/", require("@app/middleware/json-only"));

--- a/app/index.js
+++ b/app/index.js
@@ -1,12 +1,25 @@
 const express = require("express");
 const handleAsync = require("@app/middleware/handle-async");
+const basicAuth = require("express-basic-auth");
 const session = require("@app/middleware/jwt-session");
 const auth = session.authenticate;
+const basicAuthCfg = require("@app/config").basicAuth;
 
 const app = express();
 
 app.use(require("helmet")());
 app.use(require("@app/middleware/logging"));
+
+if (basicAuthCfg.user && basicAuthCfg.password) {
+  app.use(
+    basicAuth({
+      users: {
+        [basicAuthCfg.user]: basicAuthCfg.password
+      },
+      challenge: true
+    })
+  );
+}
 
 app.use("/api/", require("cookie-parser")());
 app.use("/api/", require("@app/middleware/json-only"));

--- a/app/middleware/basic-auth.js
+++ b/app/middleware/basic-auth.js
@@ -1,0 +1,17 @@
+const basicAuth = require("express-basic-auth");
+const basicAuthCfg = require("@app/config").basicAuth;
+
+let basicAuthMiddleware = function(_req, _res, next) {
+  return next();
+};
+
+if (basicAuthCfg.user && basicAuthCfg.password) {
+  basicAuthMiddleware = basicAuth({
+    users: {
+      [basicAuthCfg.user]: basicAuthCfg.password
+    },
+    challenge: true
+  });
+}
+
+module.exports = basicAuthMiddleware;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.4",
     "express": "^4.16.3",
+    "express-basic-auth": "^1.1.6",
     "helmet": "^3.15.1",
     "jsonwebtoken": "^8.5.0",
     "lodash": "^4.17.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,7 +460,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-basic-auth@~2.0.0:
+basic-auth@^2.0.1, basic-auth@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
@@ -1479,6 +1479,13 @@ expect@^24.1.0:
     jest-matcher-utils "^24.0.0"
     jest-message-util "^24.0.0"
     jest-regex-util "^24.0.0"
+
+express-basic-auth@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/express-basic-auth/-/express-basic-auth-1.1.6.tgz#a9d20e4d8da8f7212d4865f6006f9214c4b41a20"
+  integrity sha512-fRh/UU2q/YhvY0/Pkzi3VcLyjIExveW2NOOnOGgO6yO0jKXt6zcKPVPWSrL8nlhlh+YEH5LOjz+CGFML5dJQNw==
+  dependencies:
+    basic-auth "^2.0.1"
 
 express@^4.16.3:
   version "4.16.4"


### PR DESCRIPTION
Problem
-------

Often, on a fresh app, we'd like to have basic auth so that we can start
safely deploying even before the app has a proper login system.
Alternatively, stealth mode!

Solution
--------

Add basic auth support.

To turn it on, simply set BASIC_AUTH_USER and BASIC_AUTH_PASSWORD in the
environment.

Changes
-------

* add `express-basic-auth` package
* add to `app/index.js`, add basicAuth middleware if config is present
* pull `BASIC_AUTH_*` config into the `/config/index.js` and export as
`basicAuth`
* add to readme

