### PR TITLE
Fix CircleCI workflow syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,15 @@ workflows:
               only:
                 - development
                 - master
+  cron:
+    jobs:
+      - test
+      - lint
+      - audit
     triggers:
       - schedule:
-        cron: "0 13 * * *"
-        filters:
-          branches:
-            only:
-              - master
+          cron: "0 13 * * *"
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
I tried triggering a build on master and I got this error in CircleCI:

<img width="584" alt="Screen Shot 2019-06-10 at 1 55 38 PM" src="https://user-images.githubusercontent.com/189693/59226284-7b7ac500-8b87-11e9-8553-3824c5a4d92f.png">

I think the problem is that we need a separate workflow for the scheduled builds. I gave the new workflow the name "cron". Hopefully this fixes things.

~~Also I removed the yarn cache since it requires a `yarn.lock`, which this repo no longer has.~~ I removed this commit to keep this PR focused on un-blocking Circle builds.