### PR TITLE
Set up CODEOWNERS to automate PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file controls who will be automatically assigned to review pull requests.
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @carbonfive/front-end-practice-group

--- a/.spraygun.js
+++ b/.spraygun.js
@@ -39,6 +39,7 @@ exports.setup = (projectDirectory, { chalk, shell }) => {
   shell.exec("git init -q");
   shell.exec("yarn install");
   shell.rm("-rf", ".spraygun.js");
+  shell.rm("-rf", ".github/CODEOWNERS");
   shell.rm("-rf", "LICENSE");
   shell.exec("git add -A .");
   shell.exec("git commit -n -q -m 'Init from spraygun template'");


### PR DESCRIPTION
This CODEOWNERS file will cause GitHub to automatically assign someone
(selected round-robin) from the Front-End Practice Group team as
reviewer for all PRs opened in this repository.

See:
https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team

And:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
