### PR TITLE
Use a higher quality Circle CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spraygun-express
 
-[![CircleCI](https://circleci.com/gh/carbonfive/spraygun-express/tree/main.svg?style=svg)](https://circleci.com/gh/carbonfive/spraygun-express/tree/main)
+[![CircleCI](https://circleci.com/gh/carbonfive/spraygun-express/tree/main.svg?style=shield)](https://circleci.com/gh/carbonfive/spraygun-express/tree/main)
 
 This is a Carbon Five-flavored convenience skeleton project for Express, ideal for building JSON APIs for single-page apps (SPAs).
 


### PR DESCRIPTION
before/after:

<img width="498" alt="Screen Shot 2020-10-06 at 2 57 04 PM" src="https://user-images.githubusercontent.com/189693/95264573-6ac27980-07e4-11eb-9606-baa13cd03856.png">

This matches the badge style we are using in the other spraygun repos.