### PR TITLE
Standardize on jest expect syntax

### DIFF
--- a/app/controllers/auth.test.js
+++ b/app/controllers/auth.test.js
@@ -9,32 +9,35 @@ beforeEach(() => {
 
 describe("POST /api/login", () => {
   describe("with incorrect credentials", () => {
-    it("responds with a JSON 401 error", () => {
-      return agent
+    it("responds with a JSON 401 error", async () => {
+      const response = await agent
         .post("/api/login")
         .send({ email: "user@example.com", password: "incorrect" })
-        .set("Content-Type", "application/json")
-        .expect("Content-Type", /json/)
-        .expect(401);
+        .set("Content-Type", "application/json");
+      expect(response.type).toMatch(/json/);
+      expect(response.statusCode).toEqual(401);
     });
   });
 
   describe("with correct credentials", () => {
-    it("responds with JSON", () => {
-      return agent
+    it("responds with JSON", async () => {
+      const response = await agent
         .post("/api/login")
         .send({ email: "user@example.com", password: "secret" })
-        .set("Content-Type", "application/json")
-        .expect("Content-Type", /json/)
-        .expect(200, { user: { id: 1, email: "user@example.com" } });
+        .set("Content-Type", "application/json");
+      expect(response.type).toMatch(/json/);
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual({
+        user: { id: 1, email: "user@example.com" },
+      });
     });
 
-    it("sets a jwt cookie", () => {
-      return agent
+    it("sets a jwt cookie", async () => {
+      const response = await agent
         .post("/api/login")
         .send({ email: "user@example.com", password: "secret" })
-        .set("Content-Type", "application/json")
-        .expect("set-cookie", /^jwt=.+/);
+        .set("Content-Type", "application/json");
+      expect(response.header["set-cookie"][0]).toMatch(/^jwt=.+/);
     });
 
     it("grants access to a protected route", async () => {
@@ -42,7 +45,8 @@ describe("POST /api/login", () => {
         .post("/api/login")
         .send({ email: "user@example.com", password: "secret" })
         .set("Content-Type", "application/json");
-      await agent.get("/api/secret").expect(200);
+      const response = await agent.get("/api/secret");
+      expect(response.statusCode).toEqual(200);
     });
   });
 });
@@ -53,17 +57,19 @@ describe("POST /api/logout", () => {
       return agent.post("/api/login").set("Content-Type", "application/json");
     });
 
-    it("responds with JSON", () => {
-      return agent
+    it("responds with JSON", async () => {
+      const response = await agent
         .post("/api/logout")
-        .set("Content-Type", "application/json")
-        .expect("Content-Type", /json/)
-        .expect(200, {});
+        .set("Content-Type", "application/json");
+      expect(response.type).toMatch(/json/);
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual({});
     });
 
     it("revokes access to a protected route", async () => {
       await agent.post("/api/logout").set("Content-Type", "application/json");
-      await agent.get("/api/secret").expect(401);
+      const response = await agent.get("/api/secret");
+      expect(response.statusCode).toEqual(401);
     });
   });
 });

--- a/app/controllers/hello.test.js
+++ b/app/controllers/hello.test.js
@@ -2,10 +2,9 @@ const app = require("@app");
 const request = require("supertest");
 
 describe("GET /api/hello", () => {
-  it("responds with JSON", () => {
-    return request(app)
-      .get("/api/hello")
-      .expect("Content-Type", /json/)
-      .expect(200);
+  it("responds with JSON", async () => {
+    const response = await request(app).get("/api/hello");
+    expect(response.type).toMatch(/json/);
+    expect(response.statusCode).toEqual(200);
   });
 });

--- a/app/controllers/not-found.test.js
+++ b/app/controllers/not-found.test.js
@@ -2,11 +2,11 @@ const app = require("@app");
 const request = require("supertest");
 
 describe("GET /what/ever", () => {
-  it("responds with 404 and JSON object", () => {
-    return request(app)
-      .get("/what/ever")
-      .expect(404, {
-        error: { message: "No route found for GET /what/ever", status: 404 },
-      });
+  it("responds with 404 and JSON object", async () => {
+    const response = await request(app).get("/what/ever");
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toEqual({
+      error: { message: "No route found for GET /what/ever", status: 404 },
+    });
   });
 });

--- a/app/controllers/secret.test.js
+++ b/app/controllers/secret.test.js
@@ -16,20 +16,18 @@ describe("GET /api/secret", () => {
         .set("Content-Type", "application/json");
     });
 
-    it("responds with JSON", () => {
-      return agent
-        .get("/api/secret")
-        .expect("Content-Type", /json/)
-        .expect(200);
+    it("responds with JSON", async () => {
+      const response = await agent.get("/api/secret");
+      expect(response.type).toMatch(/json/);
+      expect(response.statusCode).toEqual(200);
     });
   });
 
   describe("when not authenticated", () => {
-    it("responds with a 401 status", () => {
-      return agent
-        .get("/api/secret")
-        .expect("Content-Type", /json/)
-        .expect(401);
+    it("responds with a 401 status", async () => {
+      const response = await agent.get("/api/secret");
+      expect(response.type).toMatch(/json/);
+      expect(response.statusCode).toEqual(401);
     });
   });
 });


### PR DESCRIPTION
Jest is a common denominator for writing tests. Use the regular jest expect syntax rather than the specialized supertest version. This also fixes eslint jest/expect-expect warnings.
