### PR TITLE
Fix missing dotenv dependency in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.4",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-basic-auth": "^1.2.0",
     "helmet": "^4.6.0",
@@ -29,7 +30,6 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "dotenv": "^10.0.0",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^25.2.3",


### PR DESCRIPTION
Fixes this error when the app is run after `yarn install --production`, as in the Dockerfile:

```
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'dotenv'
Require stack:
- /app-prototype/app/config/env.js
- /app-prototype/app/config/index.js
- /app-prototype/app/middleware/jwt-session.js
- /app-prototype/app/index.js
- /app-prototype/app/server.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._resolveFilename (/app-prototype/node_modules/module-alias/index.js:49:29)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/app-prototype/app/config/env.js:5:16)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app-prototype/app/config/env.js',
    '/app-prototype/app/config/index.js',
    '/app-prototype/app/middleware/jwt-session.js',
    '/app-prototype/app/index.js',
    '/app-prototype/app/server.js'
  ]
}
```
