### PR TITLE
Change default express port to 3000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY package.json yarn.lock ./
 RUN npx yarn@1.12.1 install --production
 COPY . .
 ENV NODE_ENV=production
-EXPOSE 5000
+EXPOSE 3000
 CMD ["node", "app/server.js"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn start
 
 Verify it is working by making an HTTP request:
 
-<http://localhost:5000/api/hello>
+<http://localhost:3000/api/hello>
 
 ### Basic Auth
 
@@ -65,11 +65,11 @@ basic auth for your app.
 
 ## Task reference
 
-- **`yarn start`** starts the Express server listing on port 5000. The server is automatically restarted whenever you make changes.
+- **`yarn start`** starts the Express server listing on port 3000. The server is automatically restarted whenever you make changes.
 - **`yarn test`** runs tests in "watch" mode, automatically focusing on tests or code that were modified since the last commit. Press the `a` key after the test runner has started to watch all tests in the project.
 - **`yarn test:coverage`** runs all tests, prints coverage stats, and then exits.
 - **`yarn lint`** runs all ESLint checks and then exits.
-- **`yarn server`** starts the Express server on port 5000 (or `$PORT`, if specified). This task is intended for running the app in deployment in conjunction with `NODE_ENV=production`.
+- **`yarn server`** starts the Express server on port 3000 (or `$PORT`, if specified). This task is intended for running the app in deployment in conjunction with `NODE_ENV=production`.
 
 ---
 

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -15,7 +15,7 @@ exports.logger = {
 
 exports.express = {
   logFormat: process.env.NODE_ENV === "production" ? "combined" : "dev",
-  port: process.env.PORT || 5000,
+  port: process.env.PORT || 3000,
   verbose404: !["production", "test"].includes(process.env.NODE_ENV),
 };
 


### PR DESCRIPTION
Most dev tooling and platforms default to port 3000 as a non-privilegedport number for web servers. We had been using 5000. Switch to 3000 and update the documentation. The port can still be overridden using the `PORT` environment variable.

This brings us into alignment with the popular `serve` package, which recently switched from 5000 to 3000 as well.
