### PR TITLE
Fix "caniuse-lite is outdated" warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "shelljs": "^0.8.2",
     "supertest": "^6.1.6"
   },
+  "resolutions": {
+    "caniuse-lite": "^1.0.30001298"
+  },
   "engines": {
     "node": "^16.13.1",
     "yarn": ">=1.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,10 +1106,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001220"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001220.tgz#c080e1c8eefb99f6cc9685da6313840bdbaf4c36"
-  integrity sha512-pjC2T4DIDyGAKTL4dMvGUQaMUHRmhvPpAgNNTa14jaBWHu+bLQgvpFqElxh9L4829Fdx0PlKiMp3wnYldRtECA==
+caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001298:
+  version "1.0.30001298"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz#0e690039f62e91c3ea581673d716890512e7ec52"
+  integrity sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
Use yarn resolutions to fix the following warning:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```
